### PR TITLE
feat: remove only pnpm limit (Only build)

### DIFF
--- a/.jiek-locks/pnpm-lock.base.yaml
+++ b/.jiek-locks/pnpm-lock.base.yaml
@@ -92,8 +92,8 @@ importers:
         specifier: ^4.0.0||^5.0.0
         version: 5.8.2
       workspace-sieve:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: 0.3.0
+        version: 0.3.0
     devDependencies:
       '@ast-grep/napi':
         specifier: ^0.32.3
@@ -3859,8 +3859,8 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==, tarball: https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz}
     engines: {node: '>=0.10.0'}
 
-  workspace-sieve@0.2.0:
-    resolution: {integrity: sha512-3sMVWNh4/PQ1utrl4uWCbh8XImoAsEihVdd5D/1o24UQHcsx0Xb/+Cfv4LI6mwMXB9lsF9qZRozSOWytNErWTg==, tarball: https://registry.npmjs.org/workspace-sieve/-/workspace-sieve-0.2.0.tgz}
+  workspace-sieve@0.3.0:
+    resolution: {integrity: sha512-OzeR2x2NcYzKl1KogfHuav6+j1GkynNS/IsmILUqD4L2FygzpK1hFHz8AhpIU9+OrouhGvKW7faeOqZKD4cGfA==, tarball: https://registry.npmjs.org/workspace-sieve/-/workspace-sieve-0.3.0.tgz}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==, tarball: https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz}
@@ -7870,7 +7870,7 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workspace-sieve@0.2.0:
+  workspace-sieve@0.3.0:
     dependencies:
       tinyglobby: 0.2.12
 

--- a/.jiek-locks/pnpm-lock.base.yaml
+++ b/.jiek-locks/pnpm-lock.base.yaml
@@ -92,8 +92,8 @@ importers:
         specifier: ^4.0.0||^5.0.0
         version: 5.8.2
       workspace-sieve:
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: ^0.2.0
+        version: 0.2.0
     devDependencies:
       '@ast-grep/napi':
         specifier: ^0.32.3
@@ -3859,8 +3859,8 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==, tarball: https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz}
     engines: {node: '>=0.10.0'}
 
-  workspace-sieve@0.1.2:
-    resolution: {integrity: sha512-Z4JBrtNZWAhxIOSw2wSeLQThBnllcpUiNPcrlQf5tIAtct6xTlc45o/uvb6MJO5rAqnyMTCvn4DDSxQcUsqNdg==, tarball: https://registry.npmjs.org/workspace-sieve/-/workspace-sieve-0.1.2.tgz}
+  workspace-sieve@0.2.0:
+    resolution: {integrity: sha512-3sMVWNh4/PQ1utrl4uWCbh8XImoAsEihVdd5D/1o24UQHcsx0Xb/+Cfv4LI6mwMXB9lsF9qZRozSOWytNErWTg==, tarball: https://registry.npmjs.org/workspace-sieve/-/workspace-sieve-0.2.0.tgz}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==, tarball: https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz}
@@ -7870,7 +7870,7 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workspace-sieve@0.1.2:
+  workspace-sieve@0.2.0:
     dependencies:
       tinyglobby: 0.2.12
 

--- a/packages/jiek/package.json
+++ b/packages/jiek/package.json
@@ -79,7 +79,7 @@
     "koa": "^2.15.3",
     "magic-string": "^0.30.17",
     "rollup": "^4.0.0",
-    "workspace-sieve": "^0.2.0"
+    "workspace-sieve": "0.3.0"
   },
   "devDependencies": {
     "@ast-grep/napi": "^0.32.3",

--- a/packages/jiek/package.json
+++ b/packages/jiek/package.json
@@ -79,7 +79,7 @@
     "koa": "^2.15.3",
     "magic-string": "^0.30.17",
     "rollup": "^4.0.0",
-    "workspace-sieve": "^0.1.2"
+    "workspace-sieve": "^0.2.0"
   },
   "devDependencies": {
     "@ast-grep/napi": "^0.32.3",

--- a/packages/jiek/src/utils/filterSupport.ts
+++ b/packages/jiek/src/utils/filterSupport.ts
@@ -88,7 +88,7 @@ export async function getSelectedProjectsGraph(
     filter = packageJSON.name
   }
   const { matchedGraphics } = await filterWorkspacePackagesFromDirectory(wd, {
-    patterns: workspacePatterns,
+    patterns: ['.', ...(workspacePatterns ?? [])],
     filter: [filter ?? '']
   })
   return {

--- a/packages/jiek/src/utils/filterSupport.ts
+++ b/packages/jiek/src/utils/filterSupport.ts
@@ -89,7 +89,8 @@ export async function getSelectedProjectsGraph(
   }
   const { matchedGraphics } = await filterWorkspacePackagesFromDirectory(wd, {
     patterns: ['.', ...(workspacePatterns ?? [])],
-    filter: [filter ?? '']
+    filter: [filter ?? ''],
+    experimental: true
   })
   return {
     root,

--- a/packages/jiek/src/utils/filterSupport.ts
+++ b/packages/jiek/src/utils/filterSupport.ts
@@ -1,18 +1,13 @@
 import { getRoot } from '#~/utils/getRoot'
 import { getWD } from '#~/utils/getWD'
+import type { PackageManagerType } from '#~/utils/getWD'
 import { program } from 'commander'
 import { load } from 'js-yaml'
-import childe_process from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { filterWorkspacePackagesFromDirectory } from 'workspace-sieve'
-
-export let type = ''
-try {
-  childe_process.execSync('pnpm -v')
-  type = 'pnpm'
-} catch { /* empty */ }
+import type { ProjectManifest } from 'workspace-sieve'
 
 export interface Manifest {
   name?: string
@@ -30,10 +25,38 @@ export async function filterPackagesGraph(filters: string[]): Promise<ProjectsGr
   return Promise.all(filters.map(async filter => getSelectedProjectsGraph(filter)))
 }
 
+function resolvePackageMatchPatterns(type: PackageManagerType, workspaceRoot: string) {
+  switch (type) {
+    case 'npm':
+    case 'yarn': {
+      const { workspaces } = JSON.parse(
+        fs.readFileSync(path.join(workspaceRoot, 'package.json'), 'utf-8')
+      ) as ProjectManifest
+      return workspaces
+    }
+    case 'pnpm':
+      const pnpmWorkspaceFilePath = path.resolve(workspaceRoot, 'pnpm-workspace.yaml')
+      const pnpmWorkspaceFileContent = fs.readFileSync(pnpmWorkspaceFilePath, 'utf-8')
+      const pnpmWorkspace = load(pnpmWorkspaceFileContent) as {
+        packages: string[]
+      }
+      return pnpmWorkspace.packages
+    case 'lerna':
+      const lernaWorkspaceFilePath = path.resolve(workspaceRoot, 'lerna.json')
+      const lernaWorkspaceFileContent = fs.readFileSync(lernaWorkspaceFilePath, 'utf-8')
+      const lernaWorkspace = JSON.parse(lernaWorkspaceFileContent) as {
+        packages: string[]
+      }
+      return lernaWorkspace.packages
+    default:
+      throw new Error('Unrechable code')
+  }
+}
+
 export async function getSelectedProjectsGraph(
   filter = program.getOptionValue('filter') as string | undefined
 ): Promise<ProjectsGraph> {
-  const { wd, notWorkspace } = getWD()
+  const { wd, notWorkspace, type } = getWD()
   let root = getRoot()
   if (notWorkspace) {
     return {
@@ -43,42 +66,37 @@ export async function getSelectedProjectsGraph(
       }
     }
   }
-  if (type === 'pnpm') {
-    const pnpmWorkspaceFilePath = path.resolve(wd, 'pnpm-workspace.yaml')
-    const pnpmWorkspaceFileContent = fs.readFileSync(pnpmWorkspaceFilePath, 'utf-8')
-    const pnpmWorkspace = load(pnpmWorkspaceFileContent) as {
-      packages: string[]
-    }
-    if (root === wd && (filter == null)) {
-      throw new Error('root path is workspace root, please provide a filter')
-      // TODO inquirer prompt support user select packages
-    }
-    if (root === undefined) {
-      root = process.cwd()
-    }
-    if (root !== wd && (filter == null)) {
-      const packageJSONIsExist = fs.existsSync(path.resolve(root, 'package.json'))
-      if (!packageJSONIsExist) {
-        throw new Error('root path is not workspace root, please provide a filter')
-      }
-      const packageJSON = JSON.parse(fs.readFileSync(path.resolve(root, 'package.json'), 'utf-8')) as Manifest
-      if (packageJSON.name == null) {
-        throw new Error('root path is not workspace root, please provide a filter')
-      }
-      filter = packageJSON.name
-    }
-    const { matchedGraphics } = await filterWorkspacePackagesFromDirectory(wd, {
-      patterns: pnpmWorkspace.packages,
-      filter: [filter ?? '']
-    })
-    return {
-      root,
-      value: Object.entries(matchedGraphics)
-        .reduce((acc, [key, value]) => {
-          acc[value.dirPath] = value.manifest
-          return acc
-        }, {} as NonNullable<ProjectsGraph['value']>)
-    }
+
+  const workspacePatterns = resolvePackageMatchPatterns(type, wd)
+
+  if (root === wd && (filter == null)) {
+    throw new Error('root path is workspace root, please provide a filter')
+    // TODO inquirer prompt support user select packages
   }
-  throw new Error(`not supported package manager ${type}`)
+  if (root === undefined) {
+    root = process.cwd()
+  }
+  if (root !== wd && (filter == null)) {
+    const packageJSONIsExist = fs.existsSync(path.resolve(root, 'package.json'))
+    if (!packageJSONIsExist) {
+      throw new Error('root path is not workspace root, please provide a filter')
+    }
+    const packageJSON = JSON.parse(fs.readFileSync(path.resolve(root, 'package.json'), 'utf-8')) as Manifest
+    if (packageJSON.name == null) {
+      throw new Error('root path is not workspace root, please provide a filter')
+    }
+    filter = packageJSON.name
+  }
+  const { matchedGraphics } = await filterWorkspacePackagesFromDirectory(wd, {
+    patterns: workspacePatterns,
+    filter: [filter ?? '']
+  })
+  return {
+    root,
+    value: Object.entries(matchedGraphics)
+      .reduce((acc, [key, value]) => {
+        acc[value.dirPath] = value.manifest
+        return acc
+      }, {} as NonNullable<ProjectsGraph['value']>)
+  }
 }

--- a/packages/jiek/src/utils/getWD.ts
+++ b/packages/jiek/src/utils/getWD.ts
@@ -1,33 +1,70 @@
+import fs from 'fs'
 import process from 'node:process'
 
-import { getWorkspaceDir, isWorkspaceDir } from '@jiek/utils/getWorkspaceDir'
+import path from 'node:path'
+import { searchForWorkspaceRoot } from 'workspace-sieve'
+import type { ProjectManifest } from 'workspace-sieve'
 
-import { type } from './filterSupport'
-import { getRoot } from './getRoot'
+const ROOT_FILES = ['pnpm-workspace.yaml', 'lerna.json']
 
-let wd: string
-let notWorkspace = false
+const LOCK_FILES = ['yarn.lock', 'package-lock.json']
 
-export function getWD() {
-  if (wd) return { wd, notWorkspace }
+export type PackageManagerType = 'pnpm' | 'yarn' | 'npm' | 'lerna' | 'unknown'
 
-  const root = getRoot()
-  if (root !== undefined) {
-    const isWorkspace = isWorkspaceDir(root, type)
-    notWorkspace = !isWorkspace
-    wd = root
-    return { wd, notWorkspace }
+const asserts = {
+  isPnpm: (file: string) => {
+    return file === 'pnpm-workspace.yaml'
+  },
+  isLerna: (file: string) => {
+    return file === 'lerna.json'
+  },
+  isYarn: (file: string) => {
+    return file === 'yarn.lock'
+  },
+  isNpm: (file: string) => {
+    return file === 'package-lock.json'
   }
-  try {
-    wd = getWorkspaceDir(type)
-  } catch (e) {
-    // @ts-ignore
-    if ('message' in e && e.message === 'workspace root not found') {
-      wd = root ?? process.cwd()
-      notWorkspace = true
-    } else {
-      throw e
+}
+
+export interface GetWDResult {
+  wd: string
+  notWorkspace: boolean
+  type: PackageManagerType
+}
+
+export function getWD(): GetWDResult {
+  const root = searchForWorkspaceRoot(process.cwd())
+  for (const file of ROOT_FILES) {
+    if (fs.existsSync(path.join(root, file))) {
+      return {
+        wd: root,
+        notWorkspace: false,
+        type: asserts.isPnpm(file) ? 'pnpm' : asserts.isLerna(file) ? 'lerna' : 'unknown'
+      }
     }
   }
-  return { wd, notWorkspace }
+
+  let lockFile: string = ''
+
+  for (const file of LOCK_FILES) {
+    if (fs.existsSync(path.join(root, file))) {
+      lockFile = file
+      break
+    }
+  }
+
+  try {
+    const packageJSON = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8')) as ProjectManifest
+    return {
+      wd: root,
+      notWorkspace: !!packageJSON.workspaces,
+      type: asserts.isYarn(lockFile) ? 'yarn' : asserts.isNpm(lockFile) ? 'npm' : 'unknown'
+    }
+  } catch {
+    return {
+      wd: root,
+      notWorkspace: true,
+      type: asserts.isYarn(lockFile) ? 'yarn' : asserts.isNpm(lockFile) ? 'npm' : 'unknown'
+    }
+  }
 }


### PR DESCRIPTION
# CheckList

- [x] Remove build limit (Now yarn and npm user can use this for now~)
- [x] Publish work?


## Others

jiek doesn't have any suitable test case. so that i can't test the publish work. And the most important thing is that according to the snapshot, it's determined by the user path , so the local test case will fail. : (  
If possible, we should refactor the test cases and add a workflow for pull requests.
